### PR TITLE
fixes the name in DSUStorage to match the method in Archive

### DIFF
--- a/src/controllers/base-controllers/lib/DSUStorage.js
+++ b/src/controllers/base-controllers/lib/DSUStorage.js
@@ -156,7 +156,7 @@ class DSUStorage {
           "rename",
           "unmount",
           "writeFile",
-          "listMountedDSUs",
+          "listMountedDossiers",
           "beginBatch",
           "commitBatch",
           "cancelBatch"


### PR DESCRIPTION
corrects the method name from 'listMountedDSUs' to 'listMountedDossiers' that matches Archive's method name.

It now properly connects to the method and uses it